### PR TITLE
Add dlis_sizeof_type function

### DIFF
--- a/lib/include/dlisio/types.h
+++ b/lib/include/dlisio/types.h
@@ -110,6 +110,14 @@ void* dlis_ulongo(  void*, uint32_t );
 
 void* dlis_uvario( void*, int32_t, int width );
 
+/*
+ * get the size (in bytes) of a particular data type. Expects a DLIS_UNORM or
+ * similar type code.
+ *
+ * Returns a negative value passed an invalid type code.
+ */
+int dlis_sizeof_type( int );
+
 #define DLIS_FSHORT 1  // Low precision floating point
 #define DLIS_FSINGL 2  // IEEE single precision floating point
 #define DLIS_FSING1 3  // Validated single precision floating point
@@ -137,6 +145,36 @@ void* dlis_uvario( void*, int32_t, int width );
 #define DLIS_ATTREF 25 // Attribute reference
 #define DLIS_STATUS 26 // Boolean status
 #define DLIS_UNITS  27 // Units expression
+
+#define DLIS_VARIABLE_LENGTH 0
+
+#define DLIS_SIZEOF_FSHORT 2
+#define DLIS_SIZEOF_FSINGL 4
+#define DLIS_SIZEOF_FSING1 8
+#define DLIS_SIZEOF_FSING2 12
+#define DLIS_SIZEOF_ISINGL 4
+#define DLIS_SIZEOF_VSINGL 4
+#define DLIS_SIZEOF_FDOUBL 8
+#define DLIS_SIZEOF_FDOUB1 16
+#define DLIS_SIZEOF_FDOUB2 24
+#define DLIS_SIZEOF_CSINGL 8
+#define DLIS_SIZEOF_CDOUBL 16
+#define DLIS_SIZEOF_SSHORT 1
+#define DLIS_SIZEOF_SNORM  2
+#define DLIS_SIZEOF_SLONG  4
+#define DLIS_SIZEOF_USHORT 1
+#define DLIS_SIZEOF_UNORM  2
+#define DLIS_SIZEOF_ULONG  4
+#define DLIS_SIZEOF_UVARI  DLIS_VARIABLE_LENGTH
+#define DLIS_SIZEOF_IDENT  DLIS_VARIABLE_LENGTH
+#define DLIS_SIZEOF_ASCII  DLIS_VARIABLE_LENGTH
+#define DLIS_SIZEOF_DTIME  8
+#define DLIS_SIZEOF_ORIGIN DLIS_VARIABLE_LENGTH
+#define DLIS_SIZEOF_OBNAME DLIS_VARIABLE_LENGTH
+#define DLIS_SIZEOF_OBJREF DLIS_VARIABLE_LENGTH
+#define DLIS_SIZEOF_ATTREF DLIS_VARIABLE_LENGTH
+#define DLIS_SIZEOF_STATUS 1
+#define DLIS_SIZEOF_UNITS  DLIS_VARIABLE_LENGTH
 
 #ifdef __cplusplus
 }

--- a/lib/src/types.cpp
+++ b/lib/src/types.cpp
@@ -450,3 +450,39 @@ void* dlis_uvario( void* xs, std::int32_t x, int width ) {
     std::memcpy( xs, &v, sizeof( v ) );
     return (char*)xs + sizeof( v );
 }
+
+int dlis_sizeof_type( int x ) {
+    if ( x < DLIS_FSHORT || x > DLIS_UNITS ) return -1;
+
+    constexpr const int sizes[] = {
+        DLIS_SIZEOF_FSHORT,
+        DLIS_SIZEOF_FSINGL,
+        DLIS_SIZEOF_FSING1,
+        DLIS_SIZEOF_FSING2,
+        DLIS_SIZEOF_ISINGL,
+        DLIS_SIZEOF_VSINGL,
+        DLIS_SIZEOF_FDOUBL,
+        DLIS_SIZEOF_FDOUB1,
+        DLIS_SIZEOF_FDOUB2,
+        DLIS_SIZEOF_CSINGL,
+        DLIS_SIZEOF_CDOUBL,
+        DLIS_SIZEOF_SSHORT,
+        DLIS_SIZEOF_SNORM,
+        DLIS_SIZEOF_SLONG,
+        DLIS_SIZEOF_USHORT,
+        DLIS_SIZEOF_UNORM,
+        DLIS_SIZEOF_ULONG,
+        DLIS_SIZEOF_UVARI,
+        DLIS_SIZEOF_IDENT,
+        DLIS_SIZEOF_ASCII,
+        DLIS_SIZEOF_DTIME,
+        DLIS_SIZEOF_ORIGIN,
+        DLIS_SIZEOF_OBNAME,
+        DLIS_SIZEOF_OBJREF,
+        DLIS_SIZEOF_ATTREF,
+        DLIS_SIZEOF_STATUS,
+        DLIS_SIZEOF_UNITS,
+    };
+
+    return sizes[ x - 1 ];
+}

--- a/lib/test/types.cpp
+++ b/lib/test/types.cpp
@@ -899,3 +899,33 @@ TEST_CASE("date-time", "[type]") {
     CHECK( S  == 15 );
     CHECK( MS == 620 );
 }
+
+TEST_CASE( "size-of", "[type]" ) {
+    CHECK( dlis_sizeof_type( DLIS_FSHORT ) == 2 );
+    CHECK( dlis_sizeof_type( DLIS_FSINGL ) == 4 );
+    CHECK( dlis_sizeof_type( DLIS_FSING1 ) == 8 );
+    CHECK( dlis_sizeof_type( DLIS_FSING2 ) == 12 );
+    CHECK( dlis_sizeof_type( DLIS_ISINGL ) == 4 );
+    CHECK( dlis_sizeof_type( DLIS_VSINGL ) == 4 );
+    CHECK( dlis_sizeof_type( DLIS_FDOUBL ) == 8 );
+    CHECK( dlis_sizeof_type( DLIS_FDOUB1 ) == 16 );
+    CHECK( dlis_sizeof_type( DLIS_FDOUB2 ) == 24 );
+    CHECK( dlis_sizeof_type( DLIS_CSINGL ) == 8 );
+    CHECK( dlis_sizeof_type( DLIS_CDOUBL ) == 16 );
+    CHECK( dlis_sizeof_type( DLIS_SSHORT ) == 1 );
+    CHECK( dlis_sizeof_type( DLIS_SNORM  ) == 2 );
+    CHECK( dlis_sizeof_type( DLIS_SLONG  ) == 4 );
+    CHECK( dlis_sizeof_type( DLIS_USHORT ) == 1 );
+    CHECK( dlis_sizeof_type( DLIS_UNORM  ) == 2 );
+    CHECK( dlis_sizeof_type( DLIS_ULONG  ) == 4 );
+    CHECK( dlis_sizeof_type( DLIS_UVARI  ) == 0 );
+    CHECK( dlis_sizeof_type( DLIS_IDENT  ) == 0 );
+    CHECK( dlis_sizeof_type( DLIS_ASCII  ) == 0 );
+    CHECK( dlis_sizeof_type( DLIS_DTIME  ) == 8 );
+    CHECK( dlis_sizeof_type( DLIS_ORIGIN ) == 0 );
+    CHECK( dlis_sizeof_type( DLIS_OBNAME ) == 0 );
+    CHECK( dlis_sizeof_type( DLIS_OBJREF ) == 0 );
+    CHECK( dlis_sizeof_type( DLIS_ATTREF ) == 0 );
+    CHECK( dlis_sizeof_type( DLIS_STATUS ) == 1 );
+    CHECK( dlis_sizeof_type( DLIS_UNITS  ) == 0 );
+}


### PR DESCRIPTION
A function and a set of defines to query the standard-mandated size of
data types.